### PR TITLE
Upgrade Jansi, graceful failure if not supported.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
-      <version>2.3.2</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>net.jqwik</groupId>


### PR DESCRIPTION
Address Jansi failures on M1 processors by upgrading Jansi to a version that includes a graceful failure fix.